### PR TITLE
Update readme because repo has moved to Koinos GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Koinos Contract Standard (KCS)
 
-This repository is to track and propose smart contract standards for the Koinos Blockchian. While this is not an "official" Koinos repo, since there was nothing like this available and we [(Kollection Inc.)](https://kollection.app) had a standard to propose we decided to take the initiative to put this in place. It's our hope that this repo will eventually be forked somewhere else and can become part of an "official" process as decided by the Koinos community. Until that time we're happy to get this process rolling.
+This repository is used to propose and track smart contract standards for the Koinos Blockchian. It's maintained by members of the Koinos community and the processes set forth attempt to be as decentralized as possible. Since this is an ongoing effort, the processes may change over time.
 
-## Why standards?
+## Why Standards?
 
-For the case of tokens on Koinos (including NFTs) we believe that it's important to give developers an expectation for what format of token contracts would and would not be included on exchanges or marketplaces. If a developer wishes to launch a token contract that is in line with others listed, they would want to follow a standard to be sure that it's compatible with both interfaces and aggregators that use these standards.
+For the case of tokens on Koinos we believe that it's important to give developers an expectation for what format of token contracts would and would not be included on exchanges or NFT marketplaces. If a developer wishes to launch a token contract that is in line with others listed, they would want to follow a standard to be sure that it's compatible with both interfaces and aggregators that use these standards.
 
-It's important to note that some token contracts (including NFTs) can and will have extended utility and functionality beyond a standard, but, the standard exists so that all of these types of tokens will have a base layer of expectations for software interacting with them. If there is additional utility that's intended to be duplicated by other tokens then it may be appropriate to propose a new standard that includes this additional functionality.
+It's important to note that some token contracts can and will have extended utility and functionality beyond a standard, but, the standard exists so that all of these types of tokens will have a base layer of expectations for software interacting with them. If there is additional utility that's intended to be duplicated by other tokens then it may be appropriate to propose a new standard that includes this additional functionality.
 
-## What this is not
+## What This is Not
 
 This is not a place to submit governance proposals for the Koinos Blockchain. While Ethereum uses the [EIP](https://eips.ethereum.org/EIPS) process for both chain changes and smart contract standards, KCS is specifically for contract standards. Governance proposals can be a separate process that may require a different type of decentralization. Because of this, this process does not need to be the same as EIP and can even be less extensive. Remember, the point here is to help developers and not hinder them - we want to help provide the information they need and this process is not intended to block them.
 
@@ -16,7 +16,7 @@ Developers can launch any smart contract on the Koinos blockchain whether they f
 
 ## How to Contribute
 
-Before submitting a standard you should thoroughly discuss it with other Koinos developers either on the [Koinos discord]() or on the [Koinos forum](https://discourse.koinosforum.com/).
+Before submitting a standard you should thoroughly discuss it with other Koinos developers either on the [Koinos discord](http://discord.koinos.io) or on the [Koinos forum](https://discourse.koinosforum.com/).
 
 Once you believe that your idea for a standard is sound and should be proposed, next you should write a draft describing the standard using markdown. Open an issue in this repo with simply the title of the standard. The number issued should be in order of proposals merged. The file name should be in a format like: `kcs-1.md` which includes the next available number for a standard. Open a pull request that will close your open issue. Public discussions can continue on the GitHub issue whether it's open, merged as Draft or in Final status.
 


### PR DESCRIPTION
Closes #2 - Because this repo has moved to the Koinos Group's GitHub, the `README` needs to be updated.