### PR TITLE
fix KCS-4: change direction for descending in `get_allowances`

### DIFF
--- a/KCSs/kcs-4.md
+++ b/KCSs/kcs-4.md
@@ -158,11 +158,6 @@ Returns a paginated list of allowances defined in an account.
 Protobuf definition:
 
 ```proto
-enum direction {
-   ascending = 0;
-   descending = 1;
-}
-
 message spender_value {
    bytes spender = 1 [(koinos.btype) = ADDRESS];
    uint64 value = 2 [jstype = JS_STRING];
@@ -173,7 +168,7 @@ message get_allowances_arguments {
    bytes owner = 1 [(koinos.btype) = ADDRESS];
    bytes start = 2 [(koinos.btype) = ADDRESS];
    int32 limit = 3;
-   direction direction = 4;
+   bool descending = 4;
 }
 
 // Result


### PR DESCRIPTION
This is a request from Koincity that was in the original PR #7 but somehow was not included in the final one that was merged.

The enums add a bit more complexity to developers and it's better to avoid them if possible. In this case, the `direction` only has 2 possibilities (ascending or descending), then this can be changed by a single bool called `descending`. And by default it will be `false` (ascending).

cc @mixibo